### PR TITLE
Fix typo in cp-panel

### DIFF
--- a/addon/components/cp-panel.js
+++ b/addon/components/cp-panel.js
@@ -17,7 +17,7 @@ export default Ember.Component.extend({
 
   panelActions: Ember.inject.service(),
 
-  panelState: Ember.computed('nane', function() {
+  panelState: Ember.computed('name', function() {
     const name = this.get('name');
     return this.get(`panelActions.state.${name}`);
   }),


### PR DESCRIPTION
Change `nane` -> `name`
