### PR TITLE
Provide basic default blueprint

### DIFF
--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/ember-collapsible-panel/index.js
+++ b/blueprints/ember-collapsible-panel/index.js
@@ -1,0 +1,6 @@
+/*jshint node:true*/
+module.exports = {
+  description: 'install ember-collapsible-panel into a project',
+
+  normalizeEntityName: function() {}
+};


### PR DESCRIPTION
While doing some development on a local fork of `ember-collapsible-panel`, I found the need to `npm link` it into a consuming application. The only way to have the addon's installation process triggered when doing this is for ember g <addon-name> to be run within the consuming project, so I generated a default blueprint for enabling that.

For anyone else with the same use case in the future, this would be good to include with the project 😄.
