### PR TITLE
Adds 'name' to yield hashes for use in contextual templates

### DIFF
--- a/addon/components/cp-panel/template.hbs
+++ b/addon/components/cp-panel/template.hbs
@@ -1,4 +1,5 @@
 {{yield (hash
   toggle=(component 'cp-panel-toggle' on-click=(action 'toggleIsOpen') isOpen=isOpen)
   body=(component 'cp-panel-body' shouldAnimate=shouldAnimate isOpen=isOpen)
+  name=name
 )}}

--- a/addon/components/cp-panels/template.hbs
+++ b/addon/components/cp-panels/template.hbs
@@ -1,3 +1,4 @@
 {{yield (hash
   panel=(component 'cp-panel' group=this)
+  name=name
 )}}


### PR DESCRIPTION
I've recently run into a use case for implementing custom unique ids for collapsible panels.

This pull request enables contextual components to use the name of the parent component to build unique names for panels.

Here's an example:

```handlebars
<!-- unique-panels -->
{{#cp-panels name='unique-panels' as | panels | }}

  <!-- unique-panels-panel-1 -->
  {{#panels.panel name=(concat panels.name '-panel-1') as | panel | }}

    {{#panel.toggle}}
      Panel 1
    {{/panel.toggle}}

    {{#panel.body}}
        
      <!-- unique-panels-panel-1-inner -->
      {{#cp-panels name=(concat panel.name '-inner') as | innerPanels |}}
          
          <!-- unique-panels-panel-1-inner-panel-1 -->
          {{#innerPanels.panel name=(concat innerPanels.name '-panel-1') as | innerPanel | }}

             {{#innerPanel.toggle}}
               Panel 1 Inner Panel 
             {{/innerPanel.toggle}}

            {{#innerPanel.body}}
              <!-- Use panel names in content as unique ids -->
              {{innerPanel.name}}
            {{/innerPanel.body}}

          {{/innerPanel.panel}}

        {{/each}}

      {{/cp-panels}}
      
    {{/panel.body}}
    
  {{/panels.panel}}
  
{{/cp-panels}}
```