### PR TITLE
No arguments should be passed to component hooks

### DIFF
--- a/addon/components/cp-panel/component.js
+++ b/addon/components/cp-panel/component.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
 import layout from './template';
 
-const { get } = Ember;
-
 export default Ember.Component.extend({
   layout,
 
@@ -30,11 +28,11 @@ export default Ember.Component.extend({
   panelsWrapper: null,
   animate: true,
 
-  didReceiveAttrs(attrs) {
+  didReceiveAttrs() {
     this._super(...arguments);
 
     // If caller passes in open=, use it
-    if (get(attrs, 'newAttrs.open') !== undefined) {
+    if (this.get('open') !== undefined) {
       this.set('panelState.boundOpenState', this.get('open'));
     }
   },


### PR DESCRIPTION
Component hooks shouldn't receive arguments anymore https://emberjs.com/deprecations/v2.x/#toc_arguments-in-component-lifecycle-hooks