### PR TITLE
Bump ember-cli-babel & ember-cli-htmlbars min deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6",
+    "ember-cli-babel": "^6.6.0",
     "ember-cli-version-checker": "^1.1.6",
-    "ember-cli-htmlbars": "^1.0.3"
+    "ember-cli-htmlbars": "^1.1.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
ember-cli-babel 5.x is deprecated.  Maintainers recommend ≥6.6.x.  Maintainers also use ≥1.1.1 for htmlbars.