### PR TITLE
Added disabled state to cp-panel

### DIFF
--- a/addon/components/cp-panel/component.js
+++ b/addon/components/cp-panel/component.js
@@ -12,17 +12,18 @@ export default Component.extend({
   dependencyChecker: service(),
   shouldAnimate: and('dependencyChecker.hasLiquidFire', 'animate'),
 
+  disabled: false,
+
   group: null, // passed in if rendered as part of a {{cp-panels}} group
 
   classNames: ['cp-Panel'],
-  classNameBindings: ['isOpen:cp-is-open:cp-is-closed'],
+  classNameBindings: ['isOpen:cp-is-open:cp-is-closed', 'disabled:cp-is-disabled'],
 
   // Caller can overwrite
   name: oneWay('elementId'),
 
   panelState: computed('name', function() {
     const name = this.get('name');
-    // debugger;
     return this.get(`panelActions.state.${name}`);
   }),
 
@@ -58,6 +59,9 @@ export default Component.extend({
 
   actions: {
     toggleIsOpen() {
+      if (this.get("disabled")) {
+        return;
+      }
       let name = this.get('name');
       
       this.get('panelActions').toggle(name);

--- a/tests/dummy/app/pods/demo/disabled-panel/template.hbs
+++ b/tests/dummy/app/pods/demo/disabled-panel/template.hbs
@@ -1,0 +1,27 @@
+<h3>Disabled Panel</h3>
+
+<div class="row">
+  <div class="col-md-6">
+    <p>
+      {{code-snippet name='disabled-panel.hbs'}}
+    </p>
+  </div>
+
+  <div class="col-md-6">
+
+{{!-- BEGIN-SNIPPET disabled-panel --}}
+{{#cp-panel disabled=true as |p|}}
+  {{#p.toggle}}
+    <p>Can't Click me!</p>
+  {{/p.toggle}}
+
+  {{#p.body}}
+    <div>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nemo repellendus nisi asperiores esse aperiam aliquid nulla ad dolor autem neque, nihil inventore temporibus delectus earum facere corporis, quam ipsum maxime.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Doloribus neque magnam, hic quis beatae repellendus harum modi pariatur minus quidem alias! Eius incidunt impedit eaque, est, illo officiis expedita molestiae.</p>
+    </div>
+  {{/p.body}}
+{{/cp-panel}}
+{{!-- END-SNIPPET --}}
+  </div>
+</div>

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -29,6 +29,8 @@
 
     <div class="Demo-section">{{demo/start-out-open}}</div>
 
+    <div class="Demo-section">{{demo/disabled-panel}}</div>
+
     {{!-- <div class="Demo-section">{{demo/two-way-binding}}</div> --}}
 
     {{!-- <div class="Demo-section">{{demo/one-way-binding}}</div> --}}

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -20,6 +20,9 @@
 .cp-Panel-body-inner {
   padding: 1em;
 }
+.cp-is-disabled {
+  background-color: gainsboro;
+}
 /* END-SNIPPET */
 
 /*

--- a/tests/integration/cp-panel-test.js
+++ b/tests/integration/cp-panel-test.js
@@ -259,3 +259,17 @@ test('it calls custom didToggle method when toggled', function(assert) {
   var $panel = this.$('.cp-Panel');
   $panel.find('.cp-Panel-toggle').click();
 });
+
+test('it can be disabled', function(assert) {
+  this.render(hbs`
+    {{#cp-panel disabled=true as |p|}}
+      {{p.toggle}}
+      {{#p.body}}Hi!{{/p.body}}
+    {{/cp-panel}}
+  `);
+
+  var $panel = this.$('.cp-Panel');
+  $panel.find('.cp-Panel-toggle').click();
+
+  assert.ok($panel.find('.cp-Panel-body').text().match('Hi!') === null);
+});


### PR DESCRIPTION
I wanted a way to have a panel be disabled.
We were hacking this in a weird way but I feel that this would be useful as a feature of this addon.