### PR TITLE
update documentation: programmatic control

### DIFF
--- a/tests/dummy/app/pods/demo/programmatic-control/component.js
+++ b/tests/dummy/app/pods/demo/programmatic-control/component.js
@@ -22,6 +22,14 @@ export default Component.extend({
     togglePanelB() {
       this.get('panelActions').toggle('panelB');
     },
+
+    openPanelA() {
+      this.get('panelActions').open('panelA');
+    },
+
+    closePanelA() {
+      this.get('panelActions').close('panelA');
+    }
   }
 
 });

--- a/tests/dummy/app/pods/demo/programmatic-control/template.hbs
+++ b/tests/dummy/app/pods/demo/programmatic-control/template.hbs
@@ -17,6 +17,8 @@
   <button class='btn btn-default' {{action 'collapseAll'}}>Collapse All</button>
   <button class='btn btn-default' {{action 'togglePanelA'}}>Toggle Panel A</button>
   <button class='btn btn-default' {{action 'togglePanelB'}}>Toggle Panel B</button>
+  <button class='btn btn-default' {{action 'openPanelA'}}>Open Panel A</button>
+  <button class='btn btn-default' {{action 'closePanelA'}}>Close Panel A</button>
 </div>
 
 {{#cp-panels name='group1' as |panels|}}


### PR DESCRIPTION
Add `open` and `close` panel actions in the dummy documentation programmatic control section