### PR TITLE
Fix memory leak

### DIFF
--- a/addon/services/panel-actions.js
+++ b/addon/services/panel-actions.js
@@ -27,15 +27,6 @@ const Registry = EmberObject.extend({
     this.keys = A([]);
   },
 
-  unknownProperty(name) {
-    const state = State.create();
-
-    this.get('keys').addObject(name);
-    this.set(name, state); // eslint-disable-line ember/no-side-effects
-
-    return state;
-  },
-
   // probably not too safe, should only be used in tests
   reset() {
     this.get('keys')
@@ -51,7 +42,16 @@ const Registry = EmberObject.extend({
 export default Service.extend({
   init() {
     this._super(...arguments);
-    this._registry = Registry.create();
+    this._registry = Registry.create({
+      unknownProperty(name) {
+        const state = State.create();
+
+        this.get('keys').addObject(name);
+        this.set(name, state); // eslint-disable-line ember/no-side-effects
+
+        return state;
+      },
+    });
   },
 
   state: readOnly('_registry'),

--- a/addon/services/panel-actions.js
+++ b/addon/services/panel-actions.js
@@ -22,9 +22,19 @@ const State = EmberObject.extend({
 });
 
 const Registry = EmberObject.extend({
-  keys: computed(function() {
-    return A([]);
-  }),
+  init() {
+    this._super(...arguments);
+    this.keys = A([]);
+  },
+
+  unknownProperty(name) {
+    const state = State.create();
+
+    this.get('keys').addObject(name);
+    this.set(name, state); // eslint-disable-line ember/no-side-effects
+
+    return state;
+  },
 
   // probably not too safe, should only be used in tests
   reset() {
@@ -39,18 +49,10 @@ const Registry = EmberObject.extend({
 });
 
 export default Service.extend({
-  _registry: computed(function() {
-    return Registry.create({
-      unknownProperty: function(name) {
-        const state = State.create();
-
-        this.get('keys').addObject(name);
-        this.set(name, state); // eslint-disable-line ember/no-side-effects
-
-        return state;
-      },
-    });
-  }),
+  init() {
+    this._super(...arguments);
+    this._registry = Registry.create();
+  },
 
   state: readOnly('_registry'),
 

--- a/addon/services/panel-actions.js
+++ b/addon/services/panel-actions.js
@@ -27,6 +27,19 @@ const Registry = EmberObject.extend({
     this.keys = A([]);
   },
 
+  unknownProperty(name) {
+    if (name === 'setUnknownProperty') {
+      // For failing ember-default testing scenario
+      // https://travis-ci.org/adopted-ember-addons/ember-collapsible-panel/builds/626881977
+      return;
+    }
+    const state = State.create();
+    this.get('keys').addObject(name);
+    this.set(name, state); // eslint-disable-line ember/no-side-effects
+
+    return state;
+  },
+
   // probably not too safe, should only be used in tests
   reset() {
     this.get('keys')
@@ -42,16 +55,7 @@ const Registry = EmberObject.extend({
 export default Service.extend({
   init() {
     this._super(...arguments);
-    this._registry = Registry.create({
-      unknownProperty(name) {
-        const state = State.create();
-
-        this.get('keys').addObject(name);
-        this.set(name, state); // eslint-disable-line ember/no-side-effects
-
-        return state;
-      },
-    });
+    this._registry = Registry.create();
   },
 
   state: readOnly('_registry'),

--- a/addon/services/panel-actions.js
+++ b/addon/services/panel-actions.js
@@ -21,29 +21,33 @@ const State = EmberObject.extend({
   group: null
 });
 
+const Registry = EmberObject.create({
+  keys: A([]),
+
+  unknownProperty: function(name) {
+    const state = State.create();
+
+    this.get('keys').addObject(name);
+    this.set(name, state);
+
+    return state;
+  },
+
+  // probably not too safe, should only be used in tests
+  reset() {
+    this.get('keys')
+      .map(i => i) // copy, so we dont mess with binding/loops
+      .forEach((key) => {
+        delete this[key];
+      });
+
+    this.get('keys').clear();
+  }
+});
+
 export default Service.extend({
-  _registry: EmberObject.create({
-    keys: A([]),
-
-    unknownProperty: function(name) {
-      const state = State.create();
-
-      this.get('keys').addObject(name);
-      this.set(name, state);
-
-      return state;
-    },
-
-    // probably not too safe, should only be used in tests
-    reset() {
-      this.get('keys')
-        .map(i => i) // copy, so we dont mess with binding/loops
-        .forEach((key) => {
-          delete this[key];
-        });
-
-      this.get('keys').clear();
-    }
+  _registry: computed(function() {
+    return Registry.create()
   }),
 
   state: readOnly('_registry'),

--- a/addon/services/panel-actions.js
+++ b/addon/services/panel-actions.js
@@ -26,15 +26,6 @@ const Registry = EmberObject.extend({
     return A([]);
   }),
 
-  unknownProperty: function(name) {
-    const state = State.create();
-
-    this.get('keys').addObject(name);
-    this.set(name, state);
-
-    return state;
-  },
-
   // probably not too safe, should only be used in tests
   reset() {
     this.get('keys')
@@ -44,12 +35,21 @@ const Registry = EmberObject.extend({
       });
 
     this.get('keys').clear();
-  }
+  },
 });
 
 export default Service.extend({
   _registry: computed(function() {
-    return Registry.create()
+    return Registry.create({
+      unknownProperty: function(name) {
+        const state = State.create();
+
+        this.get('keys').addObject(name);
+        this.set(name, state);
+
+        return state;
+      },
+    });
   }),
 
   state: readOnly('_registry'),

--- a/addon/services/panel-actions.js
+++ b/addon/services/panel-actions.js
@@ -29,7 +29,7 @@ const Registry = EmberObject.extend({
   // probably not too safe, should only be used in tests
   reset() {
     this.get('keys')
-      .map(i => i) // copy, so we dont mess with binding/loops
+      .slice() // copy, so we dont mess with binding/loops
       .forEach((key) => {
         delete this[key];
       });

--- a/addon/services/panel-actions.js
+++ b/addon/services/panel-actions.js
@@ -45,7 +45,7 @@ export default Service.extend({
         const state = State.create();
 
         this.get('keys').addObject(name);
-        this.set(name, state);
+        this.set(name, state); // eslint-disable-line ember/no-side-effects
 
         return state;
       },

--- a/addon/services/panel-actions.js
+++ b/addon/services/panel-actions.js
@@ -21,8 +21,10 @@ const State = EmberObject.extend({
   group: null
 });
 
-const Registry = EmberObject.create({
-  keys: A([]),
+const Registry = EmberObject.extend({
+  keys: computed(function() {
+    return A([]);
+  }),
 
   unknownProperty: function(name) {
     const state = State.create();


### PR DESCRIPTION
Following [this guide](https://github.com/ember-best-practices/memory-leak-examples/blob/master/exercises/exercise-1.md#user-content-key-takeaways), I found a memory leak in my tests.

![Screen Shot 2019-12-18 at 3 41 08 PM](https://user-images.githubusercontent.com/463770/71121684-ef3c0100-21ac-11ea-88c0-2292e25f35c5.png)

This pointed me to `service:panel-actions`, which sets an EmberObject on its prototype under the `_registry` key.

In this PR, I move the creation of the `_registry` into the `init` hook so it's set on the Service instance and not its prototype.