### PR TITLE
Inline ember-ted-docs components/styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "ember-resolver": "^8.0.3",
     "ember-source": "~3.28.0",
     "ember-source-channel-url": "^3.0.0",
-    "ember-ted-docs": "Alonski/ember-ted-docs",
     "ember-try": "^1.4.0",
     "eslint": "^7.0.0",
     "eslint-plugin-ember": "^5.0.0",

--- a/tests/dummy/app/components/ted-page-header.hbs
+++ b/tests/dummy/app/components/ted-page-header.hbs
@@ -1,0 +1,23 @@
+<div class='tph-Banner container'>
+  <a href='https://tedconf.github.io/' class='tph-Banner__link'>
+    <img class='tph-Banner__ted-logo' src='ember-ted-docs/images/ted.png'>
+    <span class='tph-Banner__slim-logo'>Open</span><span class='tph-Banner__strong-logo'>Source</span>
+  </a>
+
+  {{#if github}}
+  <a href="{{github}}" class='tph-Banner__link pull-right'>
+    GitHub
+  </a>
+  {{/if}}
+
+</div>
+<header class='tph-Header'>
+  <div class="container">
+    <h1 class="tph-Header__subheading">{{subheading}}</h1>
+    <h1 class="tph-Header__heading">
+      <span class='tph-Header__slim-heading'>{{slim-heading}}</span><span class="tph-Header__strong-heading">{{strong-heading}}</span>
+    </h1>
+    <p class='tph-Header__text'>{{byline}}</p>
+    {{yield}}
+  </div>
+</header>

--- a/tests/dummy/app/styles/ember-ted-docs/styles.scss
+++ b/tests/dummy/app/styles/ember-ted-docs/styles.scss
@@ -1,0 +1,135 @@
+/*
+  Prefixing with etd (ember-ted-docs) to avoid collisions
+*/
+$etdRed: #E62B1E;
+$etdPurple: #441678;
+@mixin etd-above($point) {
+  @media only screen and (min-width: $point) { @content; }
+}
+@mixin etd-double-gradient($from, $to) {
+  /* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#00b7ea+0,f9332d+100 */
+  background: $from; /* Old browsers */
+  background: -moz-linear-gradient(-45deg,  $from 10%, $to 100%); /* FF3.6+ */
+  background: -webkit-gradient(linear, left top, right bottom, color-stop(10%,$from), color-stop(100%,$to)); /* Chrome,Safari4+ */
+  background: -webkit-linear-gradient(-45deg,  $from 10%,$to 100%); /* Chrome10+,Safari5.1+ */
+  background: -o-linear-gradient(-45deg,  $from 10%,$to 100%); /* Opera 11.10+ */
+  background: -ms-linear-gradient(-45deg,  $from 10%,$to 100%); /* IE10+ */
+  background: linear-gradient(135deg,  $from 10%,$to 100%); /* W3C */
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='$from', endColorstr='$to',GradientType=1 ); /* IE6-9 fallback on horizontal gradient */
+}
+@mixin etd-transition($transition...) {
+  -moz-transition:    $transition;
+  -o-transition:      $transition;
+  -webkit-transition: $transition;
+  transition:         $transition;
+}
+@mixin etd-transform($transforms) {
+     -moz-transform: $transforms;
+       -o-transform: $transforms;
+      -ms-transform: $transforms;
+  -webkit-transform: $transforms;
+          transform: $transforms;
+}
+
+.tph-Banner {
+  line-height: 40px;
+  font-size: 16px;
+
+  &__link {
+    position: relative;
+    display: inline-block;
+    color: #555;
+    padding: 4px 0;
+    border-radius: 4px;
+    opacity: 0.85;
+    @include etd-transition(all, 0.2s);
+
+    &:hover,
+    &:focus {
+      color: #444;
+      text-decoration: none;
+      opacity: 1;
+    }
+
+    &--has-arrow:hover,
+    &--has-arrow:focus {
+    }
+
+    &--animated {
+      padding: 4px 6px;
+
+      &:hover,
+      &:focus {
+        @include etd-transform(translate(-5px));
+      }
+    }
+  }
+  &__ted-logo {
+    height: 40px;
+    vertical-align: top;
+  }
+  &__slim-logo {
+    text-transform: uppercase;
+    font-weight: 200;
+  }
+  &__strong-logo {
+    text-transform: uppercase;
+    font-weight: 900;
+  }
+  &__arrow {
+    font-size: 13px;
+    vertical-align: top;
+    opacity: 0;
+    @include etd-transition(all, 0.2s);
+
+    .tph-Banner__link:hover &,
+    .tph-Banner__link:focus & {
+      opacity: 1;
+    }
+  }
+}
+.tph-Header {
+  padding: 60px 0 60px;
+  background-color: white;
+  @include etd-double-gradient($etdPurple, $etdRed);
+  border-bottom: 1px solid #999;
+  box-shadow: 0 0 4px rgba(0,0,0,.14),0 4px 8px rgba(0,0,0,.28);
+  color: white;
+  // Override these rules from ted-bootstrap for the header
+  font-smooth: auto;
+  -webkit-font-smoothing: auto;
+
+  &__subheading {
+    color: rgba(255,255,255,0.8);
+    font-weight: 200;
+    font-size: 22px;
+    margin-bottom: 10px;
+    margin-top: 0;
+    @include etd-above(700px) {
+      font-size: 30px;
+    }
+  }
+  &__heading {
+    line-height: 51px;
+    font-size: 53px;
+    font-weight: bold;
+    margin-top: 0;
+    overflow: hidden;
+    @include etd-above(700px) {
+      line-height: 1.2;
+      font-size: 63px;
+    }
+  }
+  &__slim-heading {
+    display: inline-block;
+    font-weight: 100;
+  }
+  &__strong-heading {
+    display: inline-block;
+  }
+  &__text {
+    color: rgba(255,255,255,0.7);
+    font-size: 21px;
+    font-weight: 200;
+  }
+}


### PR DESCRIPTION
This removes the ember-ted-docs addon dependency by inlining. This is specifically to avoid having to use and maintaining the long running fork.
