### PR TITLE
breaking: drop support for node 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --no-lockfile
@@ -66,7 +66,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
I was trying to update the embroider dependencies and it wouldn't let me because of engine incompatibilities 

Note: the deploy preview won't work until https://github.com/adopted-ember-addons/ember-collapsible-panel/pull/121 is merged