### PR TITLE
fix ember-source peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "webpack": "^5.78.0"
   },
   "peerDependencies": {
-    "ember-source": "^4.0.0",
+    "ember-source": "^3.20 || ^4.0.0",
     "liquid-fire": ">= 0.32.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
in https://github.com/adopted-ember-addons/ember-collapsible-panel/pull/126 I didn't notice that it added a peer-dependency on `ember-source ^4.0` 🙈 that should include 3.20+ because that's what is being tested with ember-try 👍 