### PR TITLE
testing error-handling in release-plan

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -62,12 +62,18 @@ jobs:
         id: explanation
         run: |
           set -x
-          
-          pnpm release-plan prepare
-          
-          echo 'text<<EOF' >> $GITHUB_OUTPUT
-          jq .description .release-plan.json -r >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
+
+          pnpm release-plan prepare 2> >(tee -a stderr.log >&2)
+
+          if [ $? -ne 0 ]; then
+            echo 'text<<EOF' >> $GITHUB_OUTPUT
+            cat stderr.log >> $GITHUB_OUTPUT
+            echo 'EOF' >> $GITHUB_OUTPUT
+          else
+            echo 'text<<EOF' >> $GITHUB_OUTPUT
+            jq .description .release-plan.json -r >> $GITHUB_OUTPUT
+            echo 'EOF' >> $GITHUB_OUTPUT
+          fi
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
I'm trying to get the release-plan workflows to update the PR with unlabelled prs instead of just erroring